### PR TITLE
Connection error handling and removed requirement of adding the port to the connection url.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -32,6 +32,10 @@ Connection.prototype.open = function(options, callback) {
     }
 
     db.open(function(err, db) {
+        if (err) {
+            console.error(err);
+            process.exit();
+        }
         var opened = function() {
             self.db.resolve(err, db);
             self.readyState = 1;
@@ -97,7 +101,7 @@ function parseOptions(options) {
     if (options.url) {
         var uri = url.parse(options.url);
         options.host = uri.hostname;
-        options.port = parseInt(uri.port, 10);
+        options.port = parseInt(uri.port, 10) || 27017;
         options.db = uri.pathname && uri.pathname.replace(/\//g, '');
 
         if (uri.auth) {


### PR DESCRIPTION
Raise error if MongoDb connection fail

Allow connection urls without port (defaults to 27017)
