### PR TITLE
Handle empty capped collection

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -1,4 +1,5 @@
 var events = require('events');
+var mongo = require('mongodb');
 var util = require('util');
 var Promise = require('./promise');
 
@@ -61,12 +62,10 @@ Channel.prototype.subscribe = function(query, callback) {
         if (self.closed) return;
         if (err) return self.emit('error', err);
 
-        var latest = collection.find({}).sort({ '$natural': -1 }).limit(1);
-
-        latest.nextObject(function(err, doc) {
+        self.lastDoc(function(err, doc) {
             if (err) return self.emit('error', err);
 
-            if (doc) query._id = { '$gt': doc._id };
+            query._id = { '$gt': doc._id };
 
             var options = { tailable: true, awaitdata: true, numberOfRetries: -1 };
             var cursor = collection.find(query, options).sort({ '$natural': 1 });
@@ -88,6 +87,32 @@ Channel.prototype.subscribe = function(query, callback) {
             subscribed = false;
         }
     };
+};
+
+Channel.prototype.lastDoc = function(callback) {
+    this.collection.then(function(err, collection) {
+        if (err) return callback(err);
+
+        // Atomically ensure that the capped collection
+        // contains at least a single document.
+
+        var query = { _id: { $exists: true }};
+        var sort = [['$natural', 'desc']];
+        var update = { _id: new mongo.ObjectID() };
+        var options = { upsert: true, new: true };
+
+        collection.findAndModify(query, sort, update, options, function(err, doc) {
+            if (err) return callback(err);
+
+            if (doc && doc._id) {
+                // Empty doc was inserted
+                callback(null, doc);
+            } else {
+                // Document already existed
+                collection.find({}).sort({ '$natural': -1 }).limit(1).nextObject(callback);
+            }
+        });
+    });
 };
 
 Channel.prototype.close = function() {


### PR DESCRIPTION
Cursor on empty collection is closed.  Call to `nextObject` returns `null` document.
