### PR TITLE
increase wait timeout for the channel in case its empty, hiting the data...

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -11,7 +11,9 @@ function Channel(connection, name, options) {
     this.closed = false;
 
     options || (options = {});
-    this.wait = options.wait || 100;
+
+    // This timeout will be used only if collection is empty.
+    this.wait = options.wait || 1000;
 
     var self = this;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name":         "mubsub",
-    "version":      "0.2.1",
+    "version":      "0.2.2",
     "description":  "Pub/sub for Node.js and MongoDB",
     "homepage":     "http://github.com/scttnlsn/mubsub",
     "author":       "Scott Nelson <scottbnel@gmail.com>",


### PR DESCRIPTION
...base every 100 ms per channel for empty data is too much

I know I could push directly, but I think its better you take also a look at it, and also I can't publish to npm.
