### PR TITLE
MongoDB 3.0 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     },
 
     "dependencies": {
-        "mongodb": "1.3.x"
+        "mongodb": "~2.0"
     },
 
     "devDependencies": {


### PR DESCRIPTION
For compatibility with the new MongoDB 3.0 release which does not use MONGODB-CR authentication anymore, a newer mongodb driver needs to be used.

My tests yielded no problems, but please have a look at it before merging it :-)

If there are problems, please see this as a starting point.