### PR TITLE
Upgrade to mongodb 1.4 driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     },
 
     "dependencies": {
-        "mongodb": "1.3.x"
+        "mongodb": "1.4.x"
     },
 
     "devDependencies": {


### PR DESCRIPTION
This fixes problems when connecting to mongodb 3.0, fixes problems with node 0.12 bson driver compilation on windows