### PR TITLE
channel.latest should sort by natural

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -198,6 +198,7 @@ Channel.prototype.latest = function (latest, callback) {
 
         collection
             .find(latest ? { _id: latest._id } : null, {timeout: false})
+            .sort({$natural: -1})
             .limit(1)
             .nextObject(function (err, doc) {
                 if (err || doc) return callback(err, doc, collection);

--- a/test/channel.js
+++ b/test/channel.js
@@ -3,14 +3,14 @@ var mubsub = require('../lib/index');
 var data = require('./fixtures/data');
 var helpers = require('./helpers');
 
-describe('Channel', function() {
-    beforeEach(function() {
+describe('Channel', function () {
+    beforeEach(function () {
         this.client = mubsub(helpers.uri);
         this.channel = this.client.channel('channel');
     });
 
-    it('unsubscribes properly', function(done) {
-        var subscription = this.channel.subscribe('a', function(data) {
+    it('unsubscribes properly', function (done) {
+        var subscription = this.channel.subscribe('a', function (data) {
             assert.equal(data, 'a');
             subscription.unsubscribe();
             done();
@@ -21,10 +21,10 @@ describe('Channel', function() {
         this.channel.publish('a', 'a');
     });
 
-    it('unsubscribes if channel is closed', function(done) {
+    it('unsubscribes if channel is closed', function (done) {
         var self = this;
 
-        var subscription = this.channel.subscribe('a', function(data) {
+        var subscription = this.channel.subscribe('a', function (data) {
             assert.equal(data, 'a');
             self.channel.close();
             done();
@@ -35,10 +35,10 @@ describe('Channel', function() {
         this.channel.publish('a', 'a');
     });
 
-    it('unsubscribes if client is closed', function(done) {
+    it('unsubscribes if client is closed', function (done) {
         var self = this;
 
-        var subscription = this.channel.subscribe('a', function(data) {
+        var subscription = this.channel.subscribe('a', function (data) {
             assert.equal(data, 'a');
             self.client.close();
             done();
@@ -49,11 +49,11 @@ describe('Channel', function() {
         this.channel.publish('a', 'a');
     });
 
-    it('should not emit old events to a second client', function(done) {
+    it('should not emit old events to a second client', function (done) {
         var self = this;
         var channel0 = this.client.channel('channel1');
 
-        var subscription0 = channel0.subscribe('b', function(data) {
+        var subscription0 = channel0.subscribe('b', function (data) {
             subscription0.unsubscribe();
             assert.equal(data, 'b');
 
@@ -62,7 +62,7 @@ describe('Channel', function() {
             var client1 = mubsub(helpers.uri);
             var channel1 = client1.channel('channel1');
 
-            var subscription1 = channel1.subscribe('b', function(data) {
+            var subscription1 = channel1.subscribe('b', function (data) {
                 subscription1.unsubscribe();
                 assert.equal(data, 'a');
                 done();
@@ -74,7 +74,7 @@ describe('Channel', function() {
         channel0.publish('b', 'b');
     });
 
-    it('can subscribe and publish different events', function(done) {
+    it('can subscribe and publish different events', function (done) {
         var todo = 3;
         var subscriptions = [];
 
@@ -82,7 +82,7 @@ describe('Channel', function() {
             todo--;
 
             if (!todo) {
-                subscriptions.forEach(function(subscriptions) {
+                subscriptions.forEach(function (subscriptions) {
                     subscriptions.unsubscribe();
                 });
 
@@ -90,39 +90,33 @@ describe('Channel', function() {
             }
         }
 
-        subscriptions.push(this.channel.subscribe('a', function(data) {
+        subscriptions.push(this.channel.subscribe('a', function (data) {
             assert.equal(data, 'a');
             complete();
         }));
 
-        subscriptions.push(this.channel.subscribe('b', function(data) {
-            assert.deepEqual(data, {
-                b: 1
-            });
+        subscriptions.push(this.channel.subscribe('b', function (data) {
+            assert.deepEqual(data, {b: 1});
             complete();
         }));
 
-        subscriptions.push(this.channel.subscribe('c', function(data) {
+        subscriptions.push(this.channel.subscribe('c', function (data) {
             assert.deepEqual(data, ['c']);
             complete();
         }));
 
         this.channel.publish('a', 'a');
-        this.channel.publish('b', {
-            b: 1
-        });
+        this.channel.publish('b', { b: 1 });
         this.channel.publish('c', ['c']);
     });
 
-    it('gets lots of subscribed data fast enough', function(done) {
-        var channel = this.client.channel('channel.bench', {
-            size: 1024 * 1024 * 100
-        });
-
+    it('gets lots of subscribed data fast enough', function (done) {
+        var channel = this.client.channel('channel.bench', { size: 1024 * 1024 * 100 });
+        
         var n = 5000;
         var count = 0;
 
-        var subscription = channel.subscribe('a', function(_data) {
+        var subscription = channel.subscribe('a', function (_data) {
             assert.deepEqual(_data, data);
 
             if (++count == n) {

--- a/test/channel.js
+++ b/test/channel.js
@@ -53,26 +53,25 @@ describe('Channel', function() {
         var self = this;
         var channel0 = this.client.channel('channel1');
 
-        channel0.subscribe('b', function(data) {
+        var subscription0 = channel0.subscribe('b', function(data) {
+            subscription0.unsubscribe();
             assert.equal(data, 'b');
+
+            // Client 0 have now published and received one event
+            // Client 1 should not receive that event but should get the second event
+            var client1 = mubsub(helpers.uri);
+            var channel1 = client1.channel('channel1');
+
+            var subscription1 = channel1.subscribe('b', function(data) {
+                subscription1.unsubscribe();
+                assert.equal(data, 'a');
+                done();
+            });
+
+            channel1.publish('b', 'a');
         });
 
         channel0.publish('b', 'b');
-
-        // Client 0 have now published one event
-        // Client 1 should not receive that event
-        var client1 = mubsub(helpers.uri);
-        
-        setTimeout(function() {          
-            var channel1 = client1.channel('channel1');
-            channel1.subscribe('b', function(data) {
-                assert.fail(data, '', 'unexpected event');
-            });
-        }, 1000);
-
-        setTimeout(function() {
-            done();
-        }, 1500);
     });
 
     it('can subscribe and publish different events', function(done) {


### PR DESCRIPTION
As it is now the ```latest``` function always returns the dummy document because no sorting is applied, this pull request adds natural sorting to the ```latest``` function.