### PR TITLE
set the awaitData flag on the cursor, 

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -145,6 +145,7 @@ Channel.prototype.listen = function (latest) {
                     { _id: { $gt: latest._id }},
                     {
                         tailable: true,
+                      awaitData: true,
                         timeout: false,
                         sortValue: {$natural: -1}, 
                         numberOfRetries: Number.MAX_VALUE, 

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -145,7 +145,7 @@ Channel.prototype.listen = function (latest) {
                     { _id: { $gt: latest._id }},
                     {
                         tailable: true,
-                      awaitData: true,
+                        awaitData: true,
                         timeout: false,
                         sortValue: {$natural: -1}, 
                         numberOfRetries: Number.MAX_VALUE, 


### PR DESCRIPTION
so it doesn't return immediately if there's no data; fixes #49 (see also https://github.com/christkv/mongodb-core/issues/87)

I did see https://github.com/scttnlsn/mubsub/issues/15, but I didn't experience any of the problems mentioned there in my simple test: it's possible that awaitData should only be specified when using newer versions of mongoldb-core, so for maximum compatibility this should possibly check the version being used, and set/not set the flag.