### PR TITLE
MongoClient.connect unknown options are filtered out

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -3,6 +3,25 @@ var util = require('util');
 var MongoClient = require('mongodb').MongoClient;
 var Channel = require('./channel');
 
+
+var mongoValidOptionNames = [
+  // validOptionNames
+  'poolSize', 'ssl', 'sslValidate', 'sslCA', 'sslCert',
+  'sslKey', 'sslPass', 'autoReconnect', 'noDelay', 'keepAlive', 'connectTimeoutMS',
+  'socketTimeoutMS', 'reconnectTries', 'reconnectInterval', 'ha', 'haInterval',
+  'replicaSet', 'secondaryAcceptableLatencyMS', 'acceptableLatencyMS',
+  'connectWithNoPrimary', 'authSource', 'w', 'wtimeout', 'j', 'forceServerObjectId',
+  'serializeFunctions', 'ignoreUndefined', 'raw', 'promoteLongs', 'bufferMaxEntries',
+  'readPreference', 'pkFactory', 'promiseLibrary', 'readConcern', 'maxStalenessSeconds',
+  'loggerLevel', 'logger', 'promoteValues', 'promoteBuffers', 'promoteLongs',
+  'domainsEnabled', 'keepAliveInitialDelay', 'checkServerIdentity'
+  // ignoreOptionNames
+  'native_parser',
+  // legacyOptionNames
+  'server', 'replset', 'replSet', 'mongos', 'db'
+  ];
+
+
 /**
  * Connection constructor.
  *
@@ -21,7 +40,13 @@ function Connection(uri, options) {
     if (uri.collection) {
         this.db = uri;
     } else {
-        MongoClient.connect(uri, options, function (err, db) {
+
+        var mongoOptions = {}
+        mongoValidOptionNames.forEach(function(key){
+            (options[key] !== undefined) && (mongoOptions[key] = options[key])
+        })
+
+        MongoClient.connect(uri, mongoOptions, function (err, db) {
             if (err) return self.emit('error', err);
             self.db = db;
             self.emit('connect', db);
@@ -55,7 +80,7 @@ Object.defineProperty(Connection.prototype, 'state', {
             state = 'destroyed';
         }
         else if (this.db) {
-            state = this.db.serverConfig.isConnected() 
+            state = this.db.serverConfig.isConnected()
                 ? 'connected' : 'disconnected';
         } else {
             state = 'connecting';


### PR DESCRIPTION
New `MongoClient.connect` doesn't allow unknown options.
Therefore it fails because mubsub's `Connection` module passes its own options directly without filtering them out.

The ideal solution would be to user a `options.mongoOptions` object, but it would break all projects that use mubsub.

Here is a solution which should be retrocompatible.