### PR TITLE
Update connection.js

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -14,8 +14,7 @@ function Connection(uri, options) {
     var self = this;
 
     options || (options = {});
-    options.server || (options.server = {});
-    options.server.auto_reconnect != null || (options.server.auto_reconnect = true);
+    options.autoReconnect != null || (options.autoReconnect = true);
 
     // It's a Db instance.
     if (uri.collection) {


### PR DESCRIPTION
Fix MongoDB error:

```javascript
the server/replset/mongos options are deprecated, all their options are supported at the top level of the options object [poolSize,ssl,sslValidate,sslCA,sslCert,sslKey,sslPass,autoReconnect,noDelay,keepAlive,connectTimeoutMS,socketTimeoutMS,reconnectTries,reconnectInterval,ha,haInterval,replicaSet,secondaryAcceptableLatencyMS,acceptableLatencyMS,connectWithNoPrimary,authSource,w,wtimeout,j,forceServerObjectId,serializeFunctions,ignoreUndefined,raw,promoteLongs,bufferMaxEntries,readPreference,pkFactory,promiseLibrary,readConcern,maxStalenessSeconds,loggerLevel,logger,promoteValues,promoteBuffers,promoteLongs,domainsEnabled,keepAliveInitialDelay,checkServerIdentity,validateOptions]
```